### PR TITLE
Revert to safer PyYAML

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,6 @@ tox==3.0.0
 coverage==4.5.1
 Sphinx==1.7.5
 cryptography==2.2.2
-PyYAML==4.1
+PyYAML==3.13
 pytest==3.6.2
 pyaudio==0.2.11


### PR DESCRIPTION
CI is not building with PyYAML==4.1 so I'm testing a pr with 3.13 (comes listed on the versions list)